### PR TITLE
:bug: Support mutations carried by all samples (fixed sites) in threads/convert

### DIFF
--- a/assets/samplesheet_vcf.csv
+++ b/assets/samplesheet_vcf.csv
@@ -1,2 +1,2 @@
 sample,vcf,index
-test,https://github.com/cnr-ibba/nf-treeseq/raw/refs/heads/issue-8/tests/test_dataset.focal.norm.vcf.gz,https://github.com/cnr-ibba/nf-treeseq/raw/refs/heads/issue-8/tests/test_dataset.focal.norm.vcf.gz.tbi
+test,https://github.com/cnr-ibba/nf-treeseq/raw/refs/heads/dev/tests/test_dataset.focal.norm.vcf.gz,https://github.com/cnr-ibba/nf-treeseq/raw/refs/heads/dev/tests/test_dataset.focal.norm.vcf.gz.tbi

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -107,7 +107,7 @@ process {
     }
 
     withName: "PLINK2_VCF" {
-        ext.args = "${params.plink_species ?: ''}"
+        ext.args = "${params.plink_species ?: ''} --mac 1 --make-pgen"
         publishDir = [
             enabled: false
         ]

--- a/modules/local/tsinfer/custom/main.nf
+++ b/modules/local/tsinfer/custom/main.nf
@@ -25,6 +25,7 @@ process TSINFER_CUSTOM {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     def args = task.ext.args ?: ''
+    def ne_arg = params.tsdate_ne ? "--ne ${params.tsdate_ne}" : ''
     """
     mkfifo ${prefix}.trees
 
@@ -43,7 +44,7 @@ process TSINFER_CUSTOM {
         --ancestral_ensembl ${ancestor_file} \\
         --mutation_rate "${params.mutation_rate}" \\
         --recombination_rate "${params.recombination_rate}" \\
-        --ne "${params.tsdate_ne}" \\
+        ${ne_arg} \\
         --tsdate_method "${params.tsdate_method}" \\
         --output_samples ${prefix}.samples \\
         --output_trees ${prefix}.trees \\

--- a/modules/local/tsinfer/estsfs/main.nf
+++ b/modules/local/tsinfer/estsfs/main.nf
@@ -24,6 +24,7 @@ process TSINFER_ESTSFS {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     def args = task.ext.args ?: ''
+    def ne_arg = params.tsdate_ne ? "--ne ${params.tsdate_ne}" : ''
     """
     mkfifo ${prefix}.trees
 
@@ -42,7 +43,7 @@ process TSINFER_ESTSFS {
         --ancestral_estsfs ${ancestral} \\
         --mutation_rate "${params.mutation_rate}" \\
         --recombination_rate "${params.recombination_rate}" \\
-        --ne "${params.tsdate_ne}" \\
+        ${ne_arg} \\
         --tsdate_method "${params.tsdate_method}" \\
         --output_samples ${prefix}.samples \\
         --output_trees ${prefix}.trees \\

--- a/modules/local/tsinfer/major/main.nf
+++ b/modules/local/tsinfer/major/main.nf
@@ -24,6 +24,7 @@ process TSINFER_MAJOR {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     def args = task.ext.args ?: ''
+    def ne_arg = params.tsdate_ne ? "--ne ${params.tsdate_ne}" : ''
     """
     mkfifo ${prefix}.trees
 
@@ -42,7 +43,7 @@ process TSINFER_MAJOR {
         --ancestral_as_major \\
         --mutation_rate "${params.mutation_rate}" \\
         --recombination_rate "${params.recombination_rate}" \\
-        --ne "${params.tsdate_ne}" \\
+        ${ne_arg} \\
         --tsdate_method "${params.tsdate_method}" \\
         --output_samples ${prefix}.samples \\
         --output_trees ${prefix}.trees \\

--- a/modules/local/tsinfer/reference/main.nf
+++ b/modules/local/tsinfer/reference/main.nf
@@ -24,6 +24,7 @@ process TSINFER_REFERENCE {
     script:
     def prefix = task.ext.prefix ?: "${meta.id}"
     def args = task.ext.args ?: ''
+    def ne_arg = params.tsdate_ne ? "--ne ${params.tsdate_ne}" : ''
     """
     mkfifo ${prefix}.trees
 
@@ -42,7 +43,7 @@ process TSINFER_REFERENCE {
         --ancestral_as_reference \\
         --mutation_rate "${params.mutation_rate}" \\
         --recombination_rate "${params.recombination_rate}" \\
-        --ne "${params.tsdate_ne}" \\
+        ${ne_arg} \\
         --tsdate_method "${params.tsdate_method}" \\
         --output_samples ${prefix}.samples \\
         --output_trees ${prefix}.trees \\

--- a/nextflow.config
+++ b/nextflow.config
@@ -31,7 +31,7 @@ params {
     outgroup3                       = ""
 
     // tsdate specific parameters
-    tsdate_ne                       = 10000
+    tsdate_ne                       = null
     tsdate_method                   = "variational_gamma"
 
     // threads specific parameters

--- a/nextflow.config
+++ b/nextflow.config
@@ -36,6 +36,7 @@ params {
 
     // threads specific parameters
     threads_demography_file        = ""
+    threads_ne                     = 10000
     threads_fit_to_data            = false
     threads_query_interval         = 0.01
     threads_mode                   = "wgs"

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -95,7 +95,6 @@
             "properties": {
                 "tsdate_ne": {
                     "type": "integer",
-                    "default": 10000,
                     "description": "The estimated (diploid) effective population size used to construct the (default) conditional coalescent prior"
                 },
                 "tsdate_method": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -115,7 +115,7 @@
                     "type": "string",
                     "format": "file-path",
                     "description": "Demography file for threads method",
-                    "help_text": "Required for method: threads",
+                    "help_text": "Optional for method: threads. If not provided, a default demography file will be generated using threads_ne parameter.",
                     "mimetype": "text/tsv"
                 },
                 "threads_ne": {

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -119,6 +119,12 @@
                     "help_text": "Required for method: threads",
                     "mimetype": "text/tsv"
                 },
+                "threads_ne": {
+                    "type": "integer",
+                    "default": 10000,
+                    "description": "Effective population size for the entire simulation",
+                    "help_text": "Will create a demography file with a single population of size Ne"
+                },
                 "threads_fit_to_data": {
                     "type": "boolean",
                     "description": "Whether to fit the model to the data",

--- a/subworkflows/local/utils_nfcore_nf-treeseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_nf-treeseq_pipeline/main.nf
@@ -91,8 +91,8 @@ workflow PIPELINE_INITIALISATION {
     }
 
     if (params.ancestor_method == 'threads') {
-        if (!params.threads_demography_file) {
-            error "ERROR: 'threads_demography_file' is required when ancestor_method is 'threads'"
+        if (!params.threads_demography_file && !params.threads_ne) {
+            error "ERROR: 'threads_demography_file' or 'threads_ne' is required when ancestor_method is 'threads'"
         }
     }
 

--- a/subworkflows/local/utils_nfcore_nf-treeseq_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_nf-treeseq_pipeline/main.nf
@@ -90,6 +90,25 @@ workflow PIPELINE_INITIALISATION {
         }
     }
 
+    if (params.ancestor_method in ['major', 'reference', 'custom', 'est-sfs'] &&
+        params.tsdate_ne &&
+        params.tsdate_method == 'variational_gamma') {
+
+        log.warn """
+        Parameter Compatibility Warning
+        ================================
+        Parameter:  tsdate_ne = ${params.tsdate_ne}
+        Status:     IGNORED
+        Reason:     Not compatible with current configuration
+
+        Configuration:
+            - ancestor_method:  ${params.ancestor_method}
+            - tsdate_method:    ${params.tsdate_method}
+
+        Action:     Pipeline will continue, but tsdate_ne will have no effect
+        """.stripIndent()
+    }
+
     if (params.ancestor_method == 'threads') {
         if (!params.threads_demography_file && !params.threads_ne) {
             error "ERROR: 'threads_demography_file' or 'threads_ne' is required when ancestor_method is 'threads'"

--- a/tests/threads.nf.test
+++ b/tests/threads.nf.test
@@ -11,7 +11,6 @@ nextflow_pipeline {
             params {
                 outdir = "$outputDir"
                 ancestor_method = 'threads'
-                threads_demography_file = "${projectDir}/tests/test_dataset.demo"
                 plink_species = "--chr-set 26 no-xy no-mt --allow-no-sex"
                 threads_query_interval = 0.005
             }

--- a/workflows/treeseq.nf
+++ b/workflows/treeseq.nf
@@ -97,7 +97,7 @@ workflow TREESEQ {
                     checkIfExists: true
                 )
             } else {
-                // crate a default demography file using Ne
+                // create a default demography file using Ne
                 demography_ch = channel.of("0 ${params.threads_ne}")
                     | map { content ->
                         def tsv_file = file("${workDir}/demography_default.tsv")

--- a/workflows/treeseq.nf
+++ b/workflows/treeseq.nf
@@ -90,9 +90,23 @@ workflow TREESEQ {
             ch_versions = ch_versions.mix(CUSTOM.out.versions)
         } else if (params.ancestor_method == 'threads') {
             // create tree sequences using https://palamaralab.github.io/software/threads/
-            // open demography file:
-            demography_ch = channel.fromPath( params.threads_demography_file, checkIfExists: true )
+            // open demography file (if provided) or create a default one using Ne
+            if (params.threads_demography_file) {
+                demography_ch = channel.fromPath(
+                    params.threads_demography_file,
+                    checkIfExists: true
+                )
+            } else {
+                // crate a default demography file using Ne
+                demography_ch = channel.of("0 ${params.threads_ne}")
+                    | map { content ->
+                        def tsv_file = file("${workDir}/demography_default.tsv")
+                        tsv_file.text = content
+                        return tsv_file
+                    }
+            }
 
+            // call threads subworkflow
             THREADS(
                 VCF_EXTRACT.out.vcf.join(VCF_EXTRACT.out.tbi),
                 demography_ch,


### PR DESCRIPTION
This pull request introduces improvements to the handling of effective population size parameters and demography file requirements, particularly for the "threads" ancestor method. It enhances parameter validation, provides clearer warnings to users, and increases flexibility by allowing users to specify a population size directly when a demography file is not provided. Additionally, it updates sample data references and improves PLINK2 process arguments.

**Parameter handling and validation improvements:**

* Added a new parameter `threads_ne` (default: 10000) to specify effective population size for the "threads" ancestor method, and updated schema and config accordingly. (`nextflow.config`, `nextflow_schema.json`) [[1]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL34-R39) [[2]](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6R121-R126)
* Changed `tsdate_ne` default to `null` (was 10000), updated schema, and added a warning if `tsdate_ne` is set but is incompatible with the current configuration. (`nextflow.config`, `nextflow_schema.json`, `subworkflows/local/utils_nfcore_nf-treeseq_pipeline/main.nf`) [[1]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL34-R39) [[2]](diffhunk://#diff-4ec6c97fca07ea9b1ff300c0c4488d0f097ae32a78f0e0b01e00b9df0c346eb6L98) [[3]](diffhunk://#diff-f7ee0e5721bb85c7d109eaf34106d85464750918f9eebeb9774cfc404951b793R93-R114)

**Workflow logic and usability:**

* Modified the pipeline to require either a `threads_demography_file` or `threads_ne` when using the "threads" ancestor method, and to generate a default demography file using `threads_ne` if no file is provided. (`subworkflows/local/utils_nfcore_nf-treeseq_pipeline/main.nf`, `workflows/treeseq.nf`) [[1]](diffhunk://#diff-f7ee0e5721bb85c7d109eaf34106d85464750918f9eebeb9774cfc404951b793R93-R114) [[2]](diffhunk://#diff-09caf3290fbfd65637bad5485e4867f8c2446192e3b92c6e20afa2fb6b99868fL93-R109)
* Updated the test workflow to remove the explicit `threads_demography_file`, relying on the new default behavior. (`tests/threads.nf.test`)

**Other updates:**

* Updated the sample sheet VCF URLs to point to the `dev` branch. (`assets/samplesheet_vcf.csv`)
* Enhanced the PLINK2 process arguments to include `--mac 1 --make-pgen` for improved compatibility. (`conf/modules.config`)